### PR TITLE
fix: change the background of dropdowns

### DIFF
--- a/templates/classify.html
+++ b/templates/classify.html
@@ -747,7 +747,7 @@
                                 <div class="btn-toolbar justify-content-start container-fluid" role="toolbar" aria-label="Dropdown classification menus">
                                     <div class="btn-group mb-2 me-2" role="group" aria-label="Dropdown classifications">
                                         <div class="dropdown ">
-                                            <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false" onclick="setBold(this)" data-original-text="Ambiguous">
+                                            <button class="btn btn-outline-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false" onclick="setBold(this)" data-original-text="Ambiguous">
                                                 Ambiguous
                                             </button>
                                             <ul class="dropdown-menu">
@@ -760,7 +760,7 @@
                                             </ul>
                                         </div>
                                         <div class="dropdown container-fluid">
-                                            <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false" onclick="setBold(this)" data-original-text="Stars/Artifacts">
+                                            <button class="btn btn-outline-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false" onclick="setBold(this)" data-original-text="Stars/Artifacts">
                                                 Stars/Artifacts
                                             </button>
                                             <ul class="dropdown-menu">


### PR DESCRIPTION
For Ambiguous and Stars/Artifacts

## Summary by Sourcery

Enhancements:
- Restyle Ambiguous and Stars/Artifacts classification dropdown buttons to use outline-primary styling.